### PR TITLE
Add main entry module

### DIFF
--- a/shortcut/__main__.py
+++ b/shortcut/__main__.py
@@ -1,0 +1,2 @@
+import shortcut
+shortcut.main()


### PR DESCRIPTION
This allows calling `python -m shortcut whatever` to create a shortcut for the `whatever` file. Currently the shortcut binary must be in your system path to be able to use it and this allows using the existing `python` binary to invoke shortcut.